### PR TITLE
common field passes on fields to wfr, pf, qc, wfr_qc and qclist

### DIFF
--- a/docs/execution_json.rst
+++ b/docs/execution_json.rst
@@ -63,6 +63,10 @@ Example job description
         "email": true,
         "public_postrun_json" : true
       },
+      "common_fields": {
+        "award": "/awards/5UM1HL128773-04/",
+        "lab": "/labs/bing-ren-lab/"
+      },
       "custom_pf_fields": {
         "out_bam": {
             "genome_assembly": "GRCh38"
@@ -72,8 +76,7 @@ Example job description
         "notes": "a nice workflow run"
       },
       "custom_qc_fields": {
-        "award": "/awards/5UM1HL128773-04/",
-        "lab": "/labs/bing-ren-lab/"
+        "qc_note": "a nice qc"
       },
       "push_error_to_end": true
       "dependency": {
@@ -108,8 +111,9 @@ Example job description
   - The ``key_name`` field is recommended to be set ``4dn-encoded`` which is the key used by the 4DN DCIC team.
 
 - The ``push_error_to_end`` field (optional), if set true, passes any error to the last step so that the metadata can be updated with proper error status. (default true)
-- The ``custom_pf_fields`` field (optional) contains a dictionary that can be directly passed to the processed file metadata. The key may be either ``ALL`` (applies to all processed files) or the argument name for a specific processed file (or both).
-- The ``wfr_meta`` field (optional) contains a dictionary that can be directly passed to the workflow run metadata.
-- The ``custom_qc_fields`` field (optional) contains a dictionary that can be directly passed to an associated Quality Metric object.
+- The ``common_fields`` field (optional) contains a dictionary that can be directly passed to all the items created including WorkflowRun, ProcessedFile, QualityMetricWorkflowrun, QualityMetricQclist, and any other QualityMetric items. This field is overwritten by ``custom_pf_fields``, ``wfr_meta`` or ``custom_qc_fields`` if provided.
+- The ``custom_pf_fields`` field (optional) contains a dictionary that can be directly passed to the processed file metadata. The key may be either ``ALL`` (applies to all processed files) or the argument name for a specific processed file (or both). This can overwrite ``common_fields``.
+- The ``wfr_meta`` field (optional) contains a dictionary that can be directly passed to the workflow run metadata. This can overwrite ``common_fields``.
+- The ``custom_qc_fields`` field (optional) contains a dictionary that can be directly passed to an associated Quality Metric object. This field does not apply to QualityMetricWorkflowrun and QualityMetricQclist. This field can overwrite ``common_fields``.
 - The ``dependency`` field (optional) sets dependent jobs. The job will not start until the dependencies successfully finish. If dependency fails, the current job will also fail. The ``exec_arn`` is the list of step function execution arns. The job will wait at the run_task step, not at the start_task step (for consistenty with unicorn). This field will be passed to run_task as ``dependency`` inside the ``args`` field.
 

--- a/docs/execution_json.rst
+++ b/docs/execution_json.rst
@@ -76,7 +76,7 @@ Example job description
         "notes": "a nice workflow run"
       },
       "custom_qc_fields": {
-        "qc_note": "a nice qc"
+        "filtering_condition": "some condition"
       },
       "push_error_to_end": true
       "dependency": {

--- a/tests/tibanna/pony/conftest.py
+++ b/tests/tibanna/pony/conftest.py
@@ -57,173 +57,173 @@ def ff_keys(s3_utils):
     return s3_utils.get_access_keys('access_key_tibanna')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def s3_trigger_event_data():
     return get_event_file_for('validate_md5_s3_trigger')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def s3_trigger_event_data_pf():
     return get_event_file_for('validate_md5_s3_trigger', event_file='event_pf.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def s3_trigger_event_data_pf_extra_status():
     return get_event_file_for('validate_md5_s3_trigger', event_file='event_pf_extra_status.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def start_run_md5_data(ff_keys):
     return get_event_file_for('start_run', ff_keys=ff_keys, event_file='event_md5.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def start_run_md5_mount_data(ff_keys):
     return get_event_file_for('start_run', ff_keys=ff_keys, event_file='event_md5-mount.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def start_run_repliseq_data(ff_keys):
     return get_event_file_for('start_run', ff_keys=ff_keys, event_file='event_repliseq.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def start_run_pseudo_workflow_event_data(ff_keys):
     return get_event_file_for('start_run', ff_keys=ff_keys, event_file='event_metadata_only.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def start_run_nestedarray_data(ff_keys):
     return get_event_file_for('start_run', ff_keys=ff_keys, event_file='event-nestedarray.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def start_run_dependency_data(ff_keys):
     return get_event_file_for('start_run', ff_keys=ff_keys, event_file='event_dependency.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def start_run_dependency_fail_data(ff_keys):
     return get_event_file_for('start_run', ff_keys=ff_keys, event_file='event_dependency_fail.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def start_run_fail_data(ff_keys):
     return get_event_file_for('start_run', ff_keys=ff_keys, event_file='event_fail.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def start_run_fixedname_data(ff_keys):
     return get_event_file_for('start_run', ff_keys=ff_keys, event_file='event_fixedname.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def start_run_hicprocessingbam_customfield_wALL_data(ff_keys):
     return get_event_file_for('start_run', ff_keys=ff_keys, event_file='event_hicprocessingbam_customfield_wALL.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def start_run_hicprocessingbam_customfield_wArgname_data(ff_keys):
     return get_event_file_for('start_run', ff_keys=ff_keys,
                               event_file='event_hicprocessingbam_customfield_wArgname.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def start_run_hicprocessingpartb_data(ff_keys):
     return get_event_file_for('start_run', ff_keys=ff_keys, event_file='event_hicprocessingpartb.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def update_ffmeta_event_data(ff_keys):
     return get_event_file_for('update_ffmeta', ff_keys=ff_keys)
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def update_ffmeta_event_data_extra_md5(ff_keys):
     return get_event_file_for('update_ffmeta', ff_keys=ff_keys, event_file='event_extra_md5.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def update_ffmeta_event_data_newmd5(ff_keys):
     return get_event_file_for('update_ffmeta', ff_keys=ff_keys, event_file='event_newmd5.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def update_ffmeta_event_data_bed2multivec(ff_keys):
     return get_event_file_for('update_ffmeta', ff_keys=ff_keys, event_file='event_bed2multivec.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def update_ffmeta_event_data_pairsqc(ff_keys):
     return get_event_file_for('update_ffmeta', ff_keys=ff_keys, event_file='event_pairsqc.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def update_ffmeta_event_data_repliseq(ff_keys):
     return get_event_file_for('update_ffmeta', ff_keys=ff_keys, event_file='event_repliseq.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def update_ffmeta_event_data_imargi(ff_keys):
     return get_event_file_for('update_ffmeta', ff_keys=ff_keys, event_file='event_imargi.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def update_ffmeta_mcool(ff_keys):
     return get_event_file_for('update_ffmeta', ff_keys=ff_keys, event_file='event_mcool.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def update_ffmeta_event_data_fastqc(ff_keys):
     return get_event_file_for('update_ffmeta', ff_keys=ff_keys, event_file='event_fastqc.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def update_ffmeta_event_data_fastqc2(ff_keys):
     return get_event_file_for('update_ffmeta', ff_keys=ff_keys, event_file='event_fastqc2.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def update_ffmeta_event_data_chipseq(ff_keys):
     return get_event_file_for('update_ffmeta', ff_keys=ff_keys, event_file='event_chipseq.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def update_ffmeta_metaonly_data(ff_keys):
     return get_event_file_for('update_ffmeta', ff_keys=ff_keys, event_file='event_metadataonly.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def update_ffmeta_metaonly_data2(ff_keys):
     return get_event_file_for('update_ffmeta', ff_keys=ff_keys, event_file='event_metadata_2.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def update_ffmeta_tmpdata(ff_keys):
     return get_event_file_for('update_ffmeta', ff_keys=ff_keys, event_file='event_tmp.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def update_ffmeta_hicbam(ff_keys):
     return get_event_file_for('update_ffmeta', ff_keys=ff_keys, event_file='event_hicbam.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def update_ffmeta_event_data_rna_strandedness(ff_keys):
     return get_event_file_for('update_ffmeta', ff_keys=ff_keys, event_file='event_rna_strandedness.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def update_ffmeta_event_data_madqc(ff_keys):
     return get_event_file_for('update_ffmeta', ff_keys=ff_keys, event_file='event_madqc.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def update_ffmeta_event_data_fastq_first_line(ff_keys):
     return get_event_file_for('update_ffmeta', ff_keys=ff_keys, event_file='event_fastq_first_line.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def update_ffmeta_event_data_re_check(ff_keys):
     return get_event_file_for('update_ffmeta', ff_keys=ff_keys, event_file='event_re_check.json')
 

--- a/tests/tibanna/pony/test_fourfront_updater.py
+++ b/tests/tibanna/pony/test_fourfront_updater.py
@@ -47,7 +47,7 @@ def test_post_patch(update_ffmeta_event_data_fastqc2):
     assert updater.post_items['quality_metric_fastqc'][item_uuid]['uuid'] == item_uuid
     updater.create_wfr_qc()
     wfr_qc_uuid = updater.ff_meta.quality_metric
-    assert updater.post_items['QualityMetricWorkflowrun'][wfr_qc_uuid]['lab'] == "6240db37-c902-4f2a-b8eb-44a3e6ccfe11"
+    assert updater.post_items['QualityMetricWorkflowrun'][wfr_qc_uuid]['lab'] == '4dn-dcic-lab'
     updater.post_all()
     updater.update_patch_items(item_uuid, {'Per base sequence content': 'PASS'})
     updater.patch_all()

--- a/tests/tibanna/zebra/conftest.py
+++ b/tests/tibanna/zebra/conftest.py
@@ -48,27 +48,27 @@ def ff_keys(s3_utils):
     return s3_utils.get_access_keys('access_key_tibanna')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def start_run_event_md5():
     return get_event_file_for('start_run', event_file='event_md5.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def start_run_event_bwa_check():
     return get_event_file_for('start_run', event_file='event_bwa-check.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def start_run_event_vcfqc():
     return get_event_file_for('start_run', event_file='event_vcfqc.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def update_ffmeta_event_data_bamcheck(ff_keys):
     return get_event_file_for('update_ffmeta', ff_keys=ff_keys, event_file='event_bamcheck.json')
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def update_ffmeta_event_data_cmphet(ff_keys):
     return get_event_file_for('update_ffmeta', ff_keys=ff_keys, event_file='event_cmphet.json')
 

--- a/tests/tibanna/zebra/test_zebra_utils.py
+++ b/tests/tibanna/zebra/test_zebra_utils.py
@@ -1,3 +1,7 @@
+from tibanna_cgap.vars import (
+    DEFAULT_PROJECT,
+    DEFAULT_INSTITUTION
+)
 from tibanna_ffcommon.portal_utils import (
     TibannaSettings,
     FormatExtensionMap,
@@ -157,3 +161,109 @@ def test_cmphet(update_ffmeta_event_data_cmphet):
     qclist_uuid = list(updater.post_items['quality_metric_qclist'].keys())[0]
     assert 'qc_list' in updater.post_items['quality_metric_qclist'][qclist_uuid]
     assert len(updater.post_items['quality_metric_qclist'][qclist_uuid]['qc_list']) == 2
+    assert updater.post_items['quality_metric_qclist'][qclist_uuid]['project'] == DEFAULT_PROJECT
+    assert updater.post_items['quality_metric_qclist'][qclist_uuid]['institution'] == DEFAULT_INSTITUTION
+
+
+@valid_env
+def test_cmphet_custom_qc_fields(update_ffmeta_event_data_cmphet):
+    update_ffmeta_event_data_cmphet['custom_qc_fields'] = {
+        'project': '/projects/test/',
+        'institution': '/institutions/test/'
+    }
+    updater = FourfrontUpdater(**update_ffmeta_event_data_cmphet)
+    assert updater.workflow
+    assert 'arguments' in updater.workflow
+    assert updater.workflow_qc_arguments
+    assert 'comHet_vcf' in updater.workflow_qc_arguments
+    assert updater.workflow_qc_arguments['comHet_vcf'][0].qc_type == 'quality_metric_cmphet'
+    assert updater.workflow_qc_arguments['comHet_vcf'][1].qc_type == 'quality_metric_vcfcheck'
+    updater.update_qc()
+    qc1 = updater.workflow_qc_arguments['comHet_vcf'][0]
+    assert qc1.workflow_argument_name == 'comHet_vcf-json'
+    qc2 = updater.workflow_qc_arguments['comHet_vcf'][1]
+    assert qc2.workflow_argument_name == 'comHet_vcf-check'
+    assert updater.post_items
+    assert 'quality_metric_qclist' in updater.post_items
+    assert 'quality_metric_cmphet' in updater.post_items
+    assert 'quality_metric_vcfcheck' in updater.post_items
+    logger.debug("post_items[quality_metric_qclist]=" + str(updater.post_items['quality_metric_qclist']))
+    qclist_uuid = list(updater.post_items['quality_metric_qclist'].keys())[0]
+    assert 'qc_list' in updater.post_items['quality_metric_qclist'][qclist_uuid]
+    assert len(updater.post_items['quality_metric_qclist'][qclist_uuid]['qc_list']) == 2
+    # custom_qc_fields does not apply to qclist
+    assert updater.post_items['quality_metric_qclist'][qclist_uuid]['project'] == DEFAULT_PROJECT
+    assert updater.post_items['quality_metric_qclist'][qclist_uuid]['institution'] == DEFAULT_INSTITUTION
+    qc_cmphet_uuid = list(updater.post_items['quality_metric_cmphet'].keys())[0]
+    qc_vcfcheck_uuid = list(updater.post_items['quality_metric_vcfcheck'].keys())[0]
+    assert updater.post_items['quality_metric_cmphet'][qc_cmphet_uuid]['project'] == "/projects/test/"
+    assert updater.post_items['quality_metric_cmphet'][qc_cmphet_uuid]['institution'] == "/institutions/test/"
+    assert updater.post_items['quality_metric_vcfcheck'][qc_vcfcheck_uuid]['project'] == "/projects/test/"
+    assert updater.post_items['quality_metric_vcfcheck'][qc_vcfcheck_uuid]['institution'] == "/institutions/test/"
+
+
+@valid_env
+def test_cmphet_common_fields(update_ffmeta_event_data_cmphet):
+    update_ffmeta_event_data_cmphet['common_fields'] = {
+        'project': '/projects/test/',
+        'institution': '/institutions/test/'
+    }
+    updater = FourfrontUpdater(**update_ffmeta_event_data_cmphet)
+    assert updater.workflow
+    assert 'arguments' in updater.workflow
+    assert updater.workflow_qc_arguments
+    assert 'comHet_vcf' in updater.workflow_qc_arguments
+    assert updater.workflow_qc_arguments['comHet_vcf'][0].qc_type == 'quality_metric_cmphet'
+    assert updater.workflow_qc_arguments['comHet_vcf'][1].qc_type == 'quality_metric_vcfcheck'
+    updater.update_qc()
+    qc1 = updater.workflow_qc_arguments['comHet_vcf'][0]
+    assert qc1.workflow_argument_name == 'comHet_vcf-json'
+    qc2 = updater.workflow_qc_arguments['comHet_vcf'][1]
+    assert qc2.workflow_argument_name == 'comHet_vcf-check'
+    assert updater.post_items
+    assert 'quality_metric_qclist' in updater.post_items
+    assert 'quality_metric_cmphet' in updater.post_items
+    assert 'quality_metric_vcfcheck' in updater.post_items
+    logger.debug("post_items[quality_metric_qclist]=" + str(updater.post_items['quality_metric_qclist']))
+    qclist_uuid = list(updater.post_items['quality_metric_qclist'].keys())[0]
+    assert 'qc_list' in updater.post_items['quality_metric_qclist'][qclist_uuid]
+    assert len(updater.post_items['quality_metric_qclist'][qclist_uuid]['qc_list']) == 2
+    # common fields do apply to qclist
+    assert updater.post_items['quality_metric_qclist'][qclist_uuid]['project'] == "/projects/test/"
+    assert updater.post_items['quality_metric_qclist'][qclist_uuid]['institution'] == "/institutions/test/"
+    qc_cmphet_uuid = list(updater.post_items['quality_metric_cmphet'].keys())[0]
+    qc_vcfcheck_uuid = list(updater.post_items['quality_metric_vcfcheck'].keys())[0]
+    assert updater.post_items['quality_metric_cmphet'][qc_cmphet_uuid]['project'] == "/projects/test/"
+    assert updater.post_items['quality_metric_cmphet'][qc_cmphet_uuid]['institution'] == "/institutions/test/"
+    assert updater.post_items['quality_metric_vcfcheck'][qc_vcfcheck_uuid]['project'] == "/projects/test/"
+    assert updater.post_items['quality_metric_vcfcheck'][qc_vcfcheck_uuid]['institution'] == "/institutions/test/"
+
+
+@valid_env
+def test_md5_common_fields(start_run_event_md5):
+    start_run_event_md5['common_fields'] = {
+        'project': '/projects/test/',
+        'institution': '/institutions/test/'
+    }
+    starter = FourfrontStarter(**start_run_event_md5)
+    # common fields apply to wfr (ff)
+    starter.create_ff()
+    assert starter.ff.project == '/projects/test/'
+    assert starter.ff.institution == '/institutions/test/'
+
+
+@valid_env
+def test_md5_wfr_meta_common_fields(start_run_event_md5):
+    start_run_event_md5['common_fields'] = {
+        'project': '/projects/test/',
+        'institution': '/institutions/test/'
+    }
+    start_run_event_md5['wfr_meta'] = {
+        'project': '/projects/test2/',
+        'institution': '/institutions/test2/'
+    }
+    starter = FourfrontStarter(**start_run_event_md5)
+    # common fields apply to wfr (ff)
+    starter.create_ff()
+    assert starter.ff.project == '/projects/test2/'  # wfr_meta overwrites common_fields
+    assert starter.ff.institution == '/institutions/test2/'  # wfr_meta overwrites common_fields

--- a/tibanna_4dn/pony_utils.py
+++ b/tibanna_4dn/pony_utils.py
@@ -119,8 +119,10 @@ class FourfrontUpdater(FourfrontUpdaterAbstract):
 
     def create_qc_template(self):
         res = super().create_qc_template()
-        res.update({"award": DEFAULT_AWARD,
-                    "lab": DEFAULT_LAB})
+        if 'award' not in res:
+            res.update({"award": DEFAULT_AWARD})
+        if 'lab' not in res:
+            res.update({"lab": DEFAULT_LAB})
         return res
 
 

--- a/tibanna_cgap/zebra_utils.py
+++ b/tibanna_cgap/zebra_utils.py
@@ -119,8 +119,10 @@ class FourfrontUpdater(FourfrontUpdaterAbstract):
 
     def create_qc_template(self):
         res = super().create_qc_template()
-        res.update({"institution": DEFAULT_INSTITUTION,
-                    "project": DEFAULT_PROJECT})
+        if 'institution' not in res:
+            res.update({"institution": DEFAULT_INSTITUTION})
+        if 'project' not in res:
+            res.update({"project": DEFAULT_PROJECT})
         return res
 
 

--- a/tibanna_ffcommon/_version.py
+++ b/tibanna_ffcommon/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "0.16.2"
+__version__ = "0.17.0"

--- a/tibanna_ffcommon/portal_utils.py
+++ b/tibanna_ffcommon/portal_utils.py
@@ -748,7 +748,9 @@ class FourfrontStarterAbstract(object):
 
     # ff (workflowrun)-related functions
     def create_ff(self):
-        extra_meta = self.inp.common_fields
+        extra_meta = dict()
+        if self.inp.common_fields:
+            extra_meta.update(self.inp.common_fields)
         if self.inp.wfr_meta:
             extra_meta.update(self.inp.wfr_meta)
         self.ff = self.WorkflowRunMetadata(


### PR DESCRIPTION
* new field in input json, `common_fields`, is introduced which passes on fields to wfr, pf, qc, wfr_qc and qclist
* The reason is because we want to be able to pass fields like projects / institution to qclist but at the same time we don't want custom_qc_fields to be passed to qclist, since they may be specific to a specific qc run (e.g `filtering_condition`). Since most cases require the same project/institution (or lab/award) for every item generated by a workflow run including wfr, pf, qc, wfr_qc, qc_list, it makes sense to use `common_fields` to be passed on commonly to all of them, and leave specific ones to `custom_pf_fields`, `wfr_meta` and `custom_qc_fields`. These three will overwrite `common_fields` if the same fields are defined in both.