### PR TITLE
Cgapwolf env name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 tibanna>=1.5.0
-dcicutils>=2.2.1,<2.3.0
+dcicutils>=2.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 tibanna>=1.5.0
-dcicutils>=2.2.1
+dcicutils>=2.2.1,<2.3.0

--- a/tests/tibanna/zebra/test_iam_utils.py
+++ b/tests/tibanna/zebra/test_iam_utils.py
@@ -34,7 +34,7 @@ def expected_policy_arn_list_for_cgap():
                           prefix + 'tibanna_zebra_cgap_bucket_access',
                           prefix + 'tibanna_zebra_cgap_cloudwatchlogs',
                           prefix + 'tibanna_zebra_cgap_dynamodb',
-                          'arn:aws:iam::643366669028:policy/ElasticBeanstalkFullAccess' % AWS_ACCOUNT_NUMBER]
+                          'arn:aws:iam::643366669028:policy/ElasticBeanstalkFullAccess' % AWS_ACCOUNT_NUMBER],
             'status_wfr': [prefix + 'tibanna_zebra_cgap_vpc_access',
                            prefix + 'tibanna_zebra_cgap_bucket_access',
                            prefix + 'tibanna_zebra_cgap_cloudwatchlogs',

--- a/tests/tibanna/zebra/test_iam_utils.py
+++ b/tests/tibanna/zebra/test_iam_utils.py
@@ -29,7 +29,7 @@ def expected_policy_arn_list_for_cgap():
                              prefix + 'tibanna_zebra_cgap_bucket_access',
                              prefix + 'tibanna_zebra_cgap_cloudwatchlogs',
                              prefix + 'tibanna_zebra_cgap_dynamodb',
-                             prefix + 'tibanna_zebra_cgap_executions',
+                             prefix + 'tibanna_zebra_cgap_executions'],
             'start_run': [prefix + 'tibanna_zebra_cgap_vpc_access',
                           prefix + 'tibanna_zebra_cgap_bucket_access',
                           prefix + 'tibanna_zebra_cgap_cloudwatchlogs',

--- a/tests/tibanna/zebra/test_iam_utils.py
+++ b/tests/tibanna/zebra/test_iam_utils.py
@@ -34,7 +34,7 @@ def expected_policy_arn_list_for_cgap():
                           prefix + 'tibanna_zebra_cgap_bucket_access',
                           prefix + 'tibanna_zebra_cgap_cloudwatchlogs',
                           prefix + 'tibanna_zebra_cgap_dynamodb',
-                          prefix + 'ElasticBeanstalkFullAccess],
+                          prefix + 'ElasticBeanstalkFullAccess'],
             'status_wfr': [prefix + 'tibanna_zebra_cgap_vpc_access',
                            prefix + 'tibanna_zebra_cgap_bucket_access',
                            prefix + 'tibanna_zebra_cgap_cloudwatchlogs',
@@ -50,7 +50,7 @@ def expected_policy_arn_list_for_cgap():
                               prefix + 'tibanna_zebra_cgap_bucket_access',
                               prefix + 'tibanna_zebra_cgap_cloudwatchlogs',
                               prefix + 'tibanna_zebra_cgap_dynamodb',
-                              prefix + 'ElasticBeanstalkFullAccess]}
+                              prefix + 'ElasticBeanstalkFullAccess']}
 
 
 def test_policy_prefix(expected_policy_arn_list_for_cgap):

--- a/tests/tibanna/zebra/test_iam_utils.py
+++ b/tests/tibanna/zebra/test_iam_utils.py
@@ -34,7 +34,7 @@ def expected_policy_arn_list_for_cgap():
                           prefix + 'tibanna_zebra_cgap_bucket_access',
                           prefix + 'tibanna_zebra_cgap_cloudwatchlogs',
                           prefix + 'tibanna_zebra_cgap_dynamodb',
-                          'arn:aws:iam::643366669028:policy/ElasticBeanstalkFullAccess' % AWS_ACCOUNT_NUMBER],
+                          prefix + 'ElasticBeanstalkFullAccess],
             'status_wfr': [prefix + 'tibanna_zebra_cgap_vpc_access',
                            prefix + 'tibanna_zebra_cgap_bucket_access',
                            prefix + 'tibanna_zebra_cgap_cloudwatchlogs',
@@ -50,7 +50,7 @@ def expected_policy_arn_list_for_cgap():
                               prefix + 'tibanna_zebra_cgap_bucket_access',
                               prefix + 'tibanna_zebra_cgap_cloudwatchlogs',
                               prefix + 'tibanna_zebra_cgap_dynamodb',
-                              'arn:aws:iam::643366669028:policy/ElasticBeanstalkFullAccess' % AWS_ACCOUNT_NUMBER]}
+                              prefix + 'ElasticBeanstalkFullAccess]}
 
 
 def test_policy_prefix(expected_policy_arn_list_for_cgap):

--- a/tests/tibanna/zebra/test_iam_utils.py
+++ b/tests/tibanna/zebra/test_iam_utils.py
@@ -29,11 +29,12 @@ def expected_policy_arn_list_for_cgap():
                              prefix + 'tibanna_zebra_cgap_bucket_access',
                              prefix + 'tibanna_zebra_cgap_cloudwatchlogs',
                              prefix + 'tibanna_zebra_cgap_dynamodb',
-                             prefix + 'tibanna_zebra_cgap_executions'],
+                             prefix + 'tibanna_zebra_cgap_executions',
             'start_run': [prefix + 'tibanna_zebra_cgap_vpc_access',
                           prefix + 'tibanna_zebra_cgap_bucket_access',
                           prefix + 'tibanna_zebra_cgap_cloudwatchlogs',
-                          prefix + 'tibanna_zebra_cgap_dynamodb'],
+                          prefix + 'tibanna_zebra_cgap_dynamodb',
+                          'arn:aws:iam::643366669028:policy/ElasticBeanstalkFullAccess' % AWS_ACCOUNT_NUMBER]
             'status_wfr': [prefix + 'tibanna_zebra_cgap_vpc_access',
                            prefix + 'tibanna_zebra_cgap_bucket_access',
                            prefix + 'tibanna_zebra_cgap_cloudwatchlogs',
@@ -48,7 +49,8 @@ def expected_policy_arn_list_for_cgap():
             'update_ffmeta': [prefix + 'tibanna_zebra_cgap_vpc_access',
                               prefix + 'tibanna_zebra_cgap_bucket_access',
                               prefix + 'tibanna_zebra_cgap_cloudwatchlogs',
-                              prefix + 'tibanna_zebra_cgap_dynamodb']}
+                              prefix + 'tibanna_zebra_cgap_dynamodb',
+                              'arn:aws:iam::643366669028:policy/ElasticBeanstalkFullAccess' % AWS_ACCOUNT_NUMBER]}
 
 
 def test_policy_prefix(expected_policy_arn_list_for_cgap):

--- a/tibanna_4dn/lambdas/requirements.txt
+++ b/tibanna_4dn/lambdas/requirements.txt
@@ -2,5 +2,5 @@ urllib3>=1.24
 Benchmark-4dn>=0.5.13
 boto3>=1.9.0
 botocore>=1.12.1
-dcicutils>=2.2.1
+dcicutils>=2.3.1
 tibanna>=1.5.0

--- a/tibanna_cgap/lambdas/requirements.txt
+++ b/tibanna_cgap/lambdas/requirements.txt
@@ -2,5 +2,5 @@ urllib3>=1.24
 Benchmark-4dn>=0.5.13
 boto3>=1.9.0
 botocore>=1.12.1
-dcicutils>=2.2.1
+dcicutils>=2.2.1,<2.3.0
 tibanna>=1.5.0

--- a/tibanna_cgap/lambdas/requirements.txt
+++ b/tibanna_cgap/lambdas/requirements.txt
@@ -2,5 +2,5 @@ urllib3>=1.24
 Benchmark-4dn>=0.5.13
 boto3>=1.9.0
 botocore>=1.12.1
-dcicutils>=2.2.1,<2.3.0
+dcicutils>=2.3.1
 tibanna>=1.5.0

--- a/tibanna_ffcommon/_version.py
+++ b/tibanna_ffcommon/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "0.22.0"
+__version__ = "0.22.1"

--- a/tibanna_ffcommon/iam_utils.py
+++ b/tibanna_ffcommon/iam_utils.py
@@ -35,8 +35,10 @@ class IAM(_IAM):
         general_lambda_policy_types = ['vpc', 'bucket', 'cloudwatch', 'dynamodb']
         execution_lambda_policy_types = general_lambda_policy_types + ['executions']
 
-        arnlist[self.start_run_lambda_name] = [self.policy_arn(_) for _ in general_lambda_policy_types]
-        arnlist[self.update_ffmeta_lambda_name] = [self.policy_arn(_) for _ in general_lambda_policy_types]
+        arnlist[self.start_run_lambda_name] = [self.policy_arn(_) for _ in general_lambda_policy_types] + \
+                                              ['arn:aws:iam::643366669028:policy/ElasticBeanstalkFullAccess']
+        arnlist[self.update_ffmeta_lambda_name] = [self.policy_arn(_) for _ in general_lambda_policy_types] + \
+                                                  ['arn:aws:iam::643366669028:policy/ElasticBeanstalkFullAccess']
         arnlist[self.run_workflow_lambda_name] = [self.policy_arn(_) for _ in execution_lambda_policy_types]
         arnlist[self.status_wfr_lambda_name] = [self.policy_arn(_) for _ in execution_lambda_policy_types]
 

--- a/tibanna_ffcommon/iam_utils.py
+++ b/tibanna_ffcommon/iam_utils.py
@@ -35,10 +35,12 @@ class IAM(_IAM):
         general_lambda_policy_types = ['vpc', 'bucket', 'cloudwatch', 'dynamodb']
         execution_lambda_policy_types = general_lambda_policy_types + ['executions']
 
+        policy_prefix = 'arn:aws:iam::' + self.account_id + ':policy/'
+
         arnlist[self.start_run_lambda_name] = [self.policy_arn(_) for _ in general_lambda_policy_types] + \
-                                              ['arn:aws:iam::643366669028:policy/ElasticBeanstalkFullAccess']
+                                              [policy_prefix + 'ElasticBeanstalkFullAccess']
         arnlist[self.update_ffmeta_lambda_name] = [self.policy_arn(_) for _ in general_lambda_policy_types] + \
-                                                  ['arn:aws:iam::643366669028:policy/ElasticBeanstalkFullAccess']
+                                                  [policy_prefix + 'ElasticBeanstalkFullAccess']
         arnlist[self.run_workflow_lambda_name] = [self.policy_arn(_) for _ in execution_lambda_policy_types]
         arnlist[self.status_wfr_lambda_name] = [self.policy_arn(_) for _ in execution_lambda_policy_types]
 


### PR DESCRIPTION
This one uses dcicutils 2.3.1 which fixes the s3utils error during tibanna zebra deployment with env name `cgapwolf` and the s3 not found from TibannaSettings error from deployed zebra due to missing EB permission. 