### PR TITLE
Load metadata directly from database

### DIFF
--- a/tibanna_4dn/pony_utils.py
+++ b/tibanna_4dn/pony_utils.py
@@ -77,13 +77,13 @@ class FourfrontStarter(FourfrontStarterAbstract):
             infile_meta = get_metadata(inf_uuid,
                                        key=self.tbn.ff_keys,
                                        ff_env=self.tbn.env,
-                                       add_on='frame=object')
+                                       add_on='frame=object&datastore=database')
             if infile_meta.get('experiments'):
                 for exp in infile_meta.get('experiments'):
                     exp_obj = get_metadata(exp,
                                            key=self.tbn.ff_keys,
                                            ff_env=self.tbn.env,
-                                           add_on='frame=raw')
+                                           add_on='frame=raw&datastore=database')
                     pf_source_experiments_set.add(exp_obj['uuid'])
             if infile_meta.get('source_experiments'):
                 # this field is an array of strings, not linkTo's

--- a/tibanna_cgap/zebra_utils.py
+++ b/tibanna_cgap/zebra_utils.py
@@ -77,13 +77,13 @@ class FourfrontStarter(FourfrontStarterAbstract):
             infile_meta = get_metadata(inf_uuid,
                                        key=self.tbn.ff_keys,
                                        ff_env=self.tbn.env,
-                                       add_on='frame=object')
+                                       add_on='frame=object&datastore=database')
             if infile_meta.get('samples'):
                 for exp in infile_meta.get('samples'):
                     exp_obj = get_metadata(exp,
                                            key=self.tbn.ff_keys,
                                            ff_env=self.tbn.env,
-                                           add_on='frame=raw')
+                                           add_on='frame=raw&datastore=database')
                     pf_source_samples_set.add(exp_obj['uuid'])
             if infile_meta.get('source_samples'):
                 # this field is an array of strings, not linkTo's

--- a/tibanna_ffcommon/_version.py
+++ b/tibanna_ffcommon/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "0.22.6"
+__version__ = "0.22.7"

--- a/tibanna_ffcommon/input_files.py
+++ b/tibanna_ffcommon/input_files.py
@@ -379,7 +379,7 @@ class FFInputFile(SerializableObject):
                 self._metadata[id] = get_metadata(id,
                                                   key=self.ff_key,
                                                   ff_env=self.ff_env,
-                                                  add_on='frame=object',
+                                                  add_on='frame=object&datastore=database',
                                                   check_queue=True)
             except Exception as e:
                 raise FdnConnectionException(e)

--- a/tibanna_ffcommon/portal_utils.py
+++ b/tibanna_ffcommon/portal_utils.py
@@ -170,7 +170,7 @@ class FFInputAbstract(SerializableObject):
                 self._metadata[id] = get_metadata(id,
                                                   key=self.tibanna_settings.ff_keys,
                                                   ff_env=self.tibanna_settings.env,
-                                                  add_on='frame=object',
+                                                  add_on='frame=object&datastore=database',
                                                   check_queue=True)
             except Exception as e:
                 raise FdnConnectionException(e)
@@ -447,7 +447,7 @@ class FourfrontStarterAbstract(object):
             return get_metadata(uuid,
                                 key=self.tbn.ff_keys,
                                 ff_env=self.tbn.env,
-                                add_on='frame=object',
+                                add_on='frame=object&datastore=database',
                                 check_queue=check_queue)
         except Exception as e:
             raise FdnConnectionException(e)
@@ -821,7 +821,7 @@ class FourfrontUpdaterAbstract(object):
                 self._metadata[id] = get_metadata(id,
                                                   key=self.tibanna_settings.ff_keys,
                                                   ff_env=self.tibanna_settings.env,
-                                                  add_on='frame=object',
+                                                  add_on='frame=object&datastore=database',
                                                   check_queue=True)
             except Exception as e:
                 raise FdnConnectionException(e)

--- a/tibanna_ffcommon/qc.py
+++ b/tibanna_ffcommon/qc.py
@@ -294,7 +294,7 @@ class QCArgumentsPerTarget(object):
                 self._metadata[id] = get_metadata(id,
                                                   key=self.ff_key,
                                                   ff_env=self.ff_env,
-                                                  add_on='frame=object',
+                                                  add_on='frame=object&datastore=database',
                                                   check_queue=True)
             except Exception as e:
                 raise FdnConnectionException(e)


### PR DESCRIPTION
Added `&datastore=database` whenever metadata is retrieved from the portal.