### PR TITLE
Fix cost updater

### DIFF
--- a/tibanna_4dn/lambdas/update_cost.py
+++ b/tibanna_4dn/lambdas/update_cost.py
@@ -1,6 +1,4 @@
-from tibanna.lambdas import update_cost_awsem as update_cost
-from tibanna.lambdas.update_cost_awsem import config
-from tibanna_ffcommon.exceptions import exception_coordinator
+from tibanna.lambdas.update_cost_awsem import handler as _handler, config
 from tibanna_4dn.vars import LAMBDA_TYPE
 
 
@@ -8,4 +6,4 @@ config['function_name'] = 'update_cost_' + LAMBDA_TYPE
 
 
 def handler(event, context):
-    return update_cost(event)
+    return _handler(event)

--- a/tibanna_4dn/stepfunction_cost_updater.py
+++ b/tibanna_4dn/stepfunction_cost_updater.py
@@ -1,9 +1,45 @@
 from tibanna.stepfunction_cost_updater import StepFunctionCostUpdater as StepFunctionCostUpdater_
-from .vars import SFN_TYPE
+from .vars import SFN_TYPE, LAMBDA_TYPE
 
 
 class StepFunctionCostUpdater(StepFunctionCostUpdater_):
     sfn_type = SFN_TYPE
+
+    @property
+    def lambda_type(self):
+        return LAMBDA_TYPE
+
+    @property
+    def sfn_state_defs(self):
+        state_defs = {
+            "Wait": {
+            "Type": "Wait",
+            "Seconds": 43200, # Check every 12h
+            "Next": "UpdateCostAwsem"
+            },
+            "UpdateCostAwsem": {
+                "Type": "Task",
+                "Resource": self.lambda_arn_prefix + "update_cost_" + self.lambda_type + self.lambda_suffix,
+                "ResultPath": "$.done",
+                "Next": "UpdateCostDone"
+            },
+            "UpdateCostDone": {
+              "Type": "Choice",
+              "Choices": [
+                {
+                  "Variable": "$.done.done",
+                  "BooleanEquals": True,
+                  "Next": "Done"
+                }
+              ],
+              "Default": "Wait"
+            },
+            "Done": {
+              "Type": "Pass",
+              "End": True
+            }
+        }
+        return state_defs
 
     @property
     def iam(self):

--- a/tibanna_cgap/core.py
+++ b/tibanna_cgap/core.py
@@ -63,7 +63,7 @@ class API(_API):
                             security_groups=security_groups, quiet=quiet)
         self.default_stepfunction_name = default_stepfunction_name
 
-    def deploy_zebra(self, suffix=None, usergroup='', subnets=None, security_groups=None, env=None, deploy_costupdater=True):
+    def deploy_zebra(self, suffix=None, usergroup='', subnets=None, security_groups=None, env=None, deploy_costupdater=False):
         if env:
             usergroup = env + '_' + usergroup if usergroup else env
         else:

--- a/tibanna_cgap/lambdas/update_cost.py
+++ b/tibanna_cgap/lambdas/update_cost.py
@@ -1,6 +1,4 @@
-from tibanna.lambdas import update_cost_awsem as update_cost
-from tibanna.lambdas.update_cost_awsem import config
-from tibanna_ffcommon.exceptions import exception_coordinator
+from tibanna.lambdas.update_cost_awsem import handler as _handler, config
 from tibanna_cgap.vars import LAMBDA_TYPE
 
 
@@ -8,4 +6,4 @@ config['function_name'] = 'update_cost_' + LAMBDA_TYPE
 
 
 def handler(event, context):
-    return update_cost(event)
+    return _handler(event)

--- a/tibanna_ffcommon/_version.py
+++ b/tibanna_ffcommon/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "0.22.7"
+__version__ = "0.22.8"


### PR DESCRIPTION
This PR
- Updates the resource string in the 4DN cost updater step function (should fix the error we currently see in the console for 4DN)
- Imports and references the Tibanna lambda correctly (should fix the error we currently see in the console for CGAP)
- Deactivates the automatic cost updater deployment for CGAP. We will rely instead on the cost estimates from Magma (which will be available in the portal in the MetaWorkflowRun item - not released yet though)