### PR TITLE
Enable new secure AMI

### DIFF
--- a/tibanna_4dn/vars.py
+++ b/tibanna_4dn/vars.py
@@ -1,5 +1,5 @@
 from tibanna_ffcommon.vars import *
-import os
+
 
 LAMBDA_TYPE = 'pony'
 SFN_TYPE = 'pony'
@@ -20,6 +20,7 @@ HIGLASS_BUCKETS = [BUCKET_NAME('data', 'FileProcessed'),
 DEV_ENV = 'webdev'
 PROD_ENV = 'data'
 
+
 def IAM_BUCKETS(env):
     iam_buckets = [BUCKET_NAME(env, 'FileProcessed'),
                    BUCKET_NAME(env, 'FileFastq'),
@@ -30,4 +31,19 @@ def IAM_BUCKETS(env):
         iam_buckets.append(GLOBAL_BUCKET_ENV)
     return iam_buckets
 
+
 DEV_SFN = 'tibanna_' + SFN_TYPE + '_' + DEV_ENV + '_' + DEV_SUFFIX
+
+
+# Secure Tibanna AMI
+# Note that this means only these regions will work (replicate AMI in main account as needed)
+# Note additionally that these AMI's all must be configured to be launchable by our AWS
+# accounts
+AMI_PER_REGION = {
+    'us-east-1': 'ami-00ad035048da98fc2',
+    'us-east-2': 'ami-0afbf1ab3268ddf17',
+}
+if AWS_REGION not in AMI_PER_REGION:
+    logger.warning("Secure Tibanna AMI for region %s is not available." % AWS_REGION)
+    raise Exception('')
+AMI_ID = AMI_PER_REGION.get(AWS_REGION, '')

--- a/tibanna_4dn/vars.py
+++ b/tibanna_4dn/vars.py
@@ -33,17 +33,3 @@ def IAM_BUCKETS(env):
 
 
 DEV_SFN = 'tibanna_' + SFN_TYPE + '_' + DEV_ENV + '_' + DEV_SUFFIX
-
-
-# Secure Tibanna AMI
-# Note that this means only these regions will work (replicate AMI in main account as needed)
-# Note additionally that these AMI's all must be configured to be launchable by our AWS
-# accounts
-AMI_PER_REGION = {
-    'us-east-1': 'ami-00ad035048da98fc2',
-    'us-east-2': 'ami-0afbf1ab3268ddf17',
-}
-if AWS_REGION not in AMI_PER_REGION:
-    logger.warning("Secure Tibanna AMI for region %s is not available." % AWS_REGION)
-    raise Exception('')
-AMI_ID = AMI_PER_REGION.get(AWS_REGION, '')

--- a/tibanna_ffcommon/_version.py
+++ b/tibanna_ffcommon/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "0.22.7"
+__version__ = "0.23.0.0b0"

--- a/tibanna_ffcommon/_version.py
+++ b/tibanna_ffcommon/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "0.23.0.0b0"
+__version__ = "0.23.0"

--- a/tibanna_ffcommon/vars.py
+++ b/tibanna_ffcommon/vars.py
@@ -24,6 +24,20 @@ _BUCKET_NAME_SYS = dict()
 _BUCKET_NAME_LOG = dict()
 
 
+# Secure Tibanna AMI
+# Note that this means only these regions will work (replicate AMI in main account as needed)
+# Note additionally that these AMI's all must be configured to be launchable by our AWS
+# accounts
+AMI_PER_REGION = {
+    'us-east-1': 'ami-00ad035048da98fc2',
+    'us-east-2': 'ami-0afbf1ab3268ddf17',
+}
+if AWS_REGION not in AMI_PER_REGION:
+    logger.warning("Secure Tibanna AMI for region %s is not available." % AWS_REGION)
+    raise Exception('')
+AMI_ID = AMI_PER_REGION.get(AWS_REGION, '')
+
+
 def BUCKET_NAME(env, filetype):
     global _BUCKET_NAME_PROCESSED_FILES
     global _BUCKET_NAME_RAW_RILES


### PR DESCRIPTION
- Override AMI mappings from Tibanna Core to use new secure AMI
- Note that these AMIs must be made available for launching from any AWS account we deploy Tibanna to