### PR TITLE
Check current file status before patching it to uploaded

### DIFF
--- a/tests/tibanna/pony/test_fourfront_updater.py
+++ b/tests/tibanna/pony/test_fourfront_updater.py
@@ -134,7 +134,6 @@ def test_md5(update_ffmeta_event_data_newmd5):
     assert 'f4864029-a8ad-4bb8-93e7-5108f462ccaa' in updater.patch_items
     assert 'md5sum' not in updater.patch_items['f4864029-a8ad-4bb8-93e7-5108f462ccaa']  # already in
     assert 'file_size' in updater.patch_items['f4864029-a8ad-4bb8-93e7-5108f462ccaa']
-    assert 'status' in updater.patch_items['f4864029-a8ad-4bb8-93e7-5108f462ccaa']
     s3.delete_object(Bucket='elasticbeanstalk-fourfront-webdev-wfoutput', Key=report_key)
 
 

--- a/tibanna_ffcommon/_version.py
+++ b/tibanna_ffcommon/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "0.23.1"
+__version__ = "0.23.2"

--- a/tibanna_ffcommon/portal_utils.py
+++ b/tibanna_ffcommon/portal_utils.py
@@ -1489,12 +1489,14 @@ class FourfrontUpdaterAbstract(object):
             secondary_format = matching_extra['file_format']
             patch_content[matching_extra_ind]['file_size'] = \
                 self.s3_file_size(input_arg, secondary_format=secondary_format)
-            patch_content[matching_extra_ind]['status'] = 'uploaded'
+            if patch_content[matching_extra_ind]['status'] in ['uploading', 'to be uploaded by workflow']:
+                patch_content[matching_extra_ind]['status'] = 'uploaded'
             self.update_patch_items(input_meta['uuid'], {'extra_files': patch_content})
         else:
             patch_content = process(input_meta)
             patch_content['file_size'] = self.s3_file_size(input_arg)
-            patch_content['status'] = 'uploaded'
+            if input_meta['status'] in ['uploading', 'to be uploaded by workflow']:
+                patch_content['status'] = 'uploaded'
             self.update_patch_items(input_meta['uuid'], patch_content)
             logger.debug(self.patch_items)
 


### PR DESCRIPTION
md5 could be run (manually) also on files with a status different than 'uploading' or 'to be uploaded by workflow'. In these cases, we do not want tibanna to patch the status to 'uploaded'.
For example, currently there are files with status 'released' that are lacking md5sum. We want to patch only the md5 value, in this case.