### PR TITLE
Accept kwargs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ notebooks/Single use scripts/Jsons/*
 # locally installed packages
 src/benchmark
 src/python-lambda
+
+# vim
+*.swp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tibanna_ff"
-version = "1.3.1"
+version = "1.3.2"
 description = "Tibanna runs portable pipelines (in CWL/WDL) on the AWS Cloud."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/tibanna_ffcommon/input_files.py
+++ b/tibanna_ffcommon/input_files.py
@@ -93,7 +93,7 @@ class FFInputFile(SerializableObject):
 
     def __init__(self, uuid=None, workflow_argument_name=None, object_key=None,
                  bucket_name=None, rename='', unzip='', mount=False,
-                 format_if_extra='', ff_key=None, ff_env=None):
+                 format_if_extra='', ff_key=None, ff_env=None, **kwargs):
         # uuid and workflow_argument_name are required
         if not uuid or not workflow_argument_name:
             raise MalFormattedFFInputException("malformed input, check input_files in your input json")

--- a/tibanna_ffcommon/portal_utils.py
+++ b/tibanna_ffcommon/portal_utils.py
@@ -368,7 +368,7 @@ def ensure_list(val):
 
 class TibannaSettings(SerializableObject):
 
-    def __init__(self, env=None, ff_keys=None, sbg_keys=None, settings=None):
+    def __init__(self, env=None, ff_keys=None, sbg_keys=None, settings=None, **kwargs):
         if not env:
             self.env = None
             self.s3 = None

--- a/tibanna_ffcommon/qc.py
+++ b/tibanna_ffcommon/qc.py
@@ -23,7 +23,7 @@ class QCArgument(SerializableObject):
     def __init__(self, argument_type, workflow_argument_name, argument_to_be_attached_to, qc_type=None,
                  qc_zipped=False, qc_html=False, qc_json=False, qc_table=False,
                  qc_zipped_html=None, qc_zipped_tables=None, qc_acl='public-read',
-                 qc_unzip_from_ec2=False):
+                 qc_unzip_from_ec2=False, **kwargs):
         if argument_type != 'Output QC file':
             raise Exception("QC Argument must be an Output QC file: %s" % argument_type)
         self.workflow_argument_name = workflow_argument_name

--- a/tibanna_ffcommon/wfr.py
+++ b/tibanna_ffcommon/wfr.py
@@ -135,7 +135,7 @@ class InputFileForWFRMeta(object):
     defined in the InputFilesForWFRMeta class.
     """
     def __init__(self, workflow_argument_name=None, value=None, ordinal=None,
-                       format_if_extra=None, dimension=None):
+                       format_if_extra=None, dimension=None, **kwargs):
         """dimension is '0' for a singleton argument,
         '0', '1', '2' ... for a 1d-list argument,
         '0-0', '0-1', ... , '1-0', '1-1', ... for a 2d-list argument, and so on.


### PR DESCRIPTION
Here, we add `**kwargs` to various class constructor methods, specifically those that are used elsewhere in the form `Class(**properties)`. 

See corresponding tibanna PR here: https://github.com/4dn-dcic/tibanna/pull/387.