### PR TITLE
Use only core file types to determine correct bucket in SMaHT

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Change Log
 ==========
 
+3.5.1
+=====
+* Consider only core file types when determining the correct bucket of an input file
+
 3.5.0
 =====
 * Support for Python 3.12.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,11 +2,11 @@
 Change Log
 ==========
 
-3.5.1
+3.6.0
 =====
-* Consider only core file types when determining the correct bucket of an input file
+* Consider only core file types when determining the correct bucket of an input file in SMaHT
 
-3.5.0
+3.5.0 - This version (and below) does not work for certain file types in SMaHT
 =====
 * Support for Python 3.12.
 * Added this CHANGELOG.rst file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tibanna_ff"
-version = "3.5.0"
+version = "3.5.1"
 description = "Tibanna runs portable pipelines (in CWL/WDL) on the AWS Cloud."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tibanna_ff"
-version = "3.3.0"
+version = "3.4.0"
 description = "Tibanna runs portable pipelines (in CWL/WDL) on the AWS Cloud."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tibanna_ff"
-version = "3.5.1"
+version = "3.6.0"
 description = "Tibanna runs portable pipelines (in CWL/WDL) on the AWS Cloud."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/tibanna_4dn/vars.py
+++ b/tibanna_4dn/vars.py
@@ -14,16 +14,16 @@ TIBANNA_DEFAULT_STEP_FUNCTION_NAME = 'tibanna_' + LAMBDA_TYPE
 DEFAULT_AWARD = '1U01CA200059-01'
 DEFAULT_LAB = '4dn-dcic-lab'
 
-HIGLASS_BUCKETS = [BUCKET_NAME('data', 'FileProcessed'),
-                   BUCKET_NAME('fourfront-webdev', 'FileProcessed')]
+HIGLASS_BUCKETS = [BUCKET_NAME('data', FILE_PROCESSED),
+                   BUCKET_NAME('fourfront-webdev', FILE_PROCESSED)]
 
 DEV_ENV = 'webdev'
 PROD_ENV = 'data'
 
 
 def IAM_BUCKETS(env):
-    iam_buckets = [BUCKET_NAME(env, 'FileProcessed'),
-                   BUCKET_NAME(env, 'FileFastq'),
+    iam_buckets = [BUCKET_NAME(env, FILE_PROCESSED),
+                   BUCKET_NAME(env, FILE_FASTQ),
                    '4dn-open-data-public',
                    BUCKET_NAME(env, 'system'),
                    BUCKET_NAME(env, 'log')]

--- a/tibanna_cgap/vars.py
+++ b/tibanna_cgap/vars.py
@@ -26,8 +26,8 @@ def IAM_BUCKETS(env):
     """ This function determines the buckets for which the IAM policy is generated for.
         If you want tibanna to have access to more buckets, this is where to add them.
     """
-    iam_buckets = [BUCKET_NAME(env, 'FileProcessed'),
-                   BUCKET_NAME(env, 'FileFastq'),
+    iam_buckets = [BUCKET_NAME(env, FILE_PROCESSED),
+                   BUCKET_NAME(env, FILE_FASTQ),
                    BUCKET_NAME(env, 'system'),
                    BUCKET_NAME(env, 'log'),
                    BUCKET_NAME(env, 'cwl')]

--- a/tibanna_ffcommon/portal_utils.py
+++ b/tibanna_ffcommon/portal_utils.py
@@ -44,7 +44,8 @@ from .vars import (
     GENERIC_QC_FILE,
     OUTPUT_TO_BE_EXTRA_INPUT_FILE,
     INPUT_FILE,
-    AWSF_IMAGE
+    AWSF_IMAGE,
+    FILE_PROCESSED
 )
 from .config import (
     higlass_config
@@ -180,7 +181,7 @@ class FFInputAbstract(SerializableObject):
 
         # fill in output_bucket
         if not self.output_bucket:
-            self.output_bucket = BUCKET_NAME(self.tibanna_settings.env, 'FileProcessed')
+            self.output_bucket = BUCKET_NAME(self.tibanna_settings.env, FILE_PROCESSED)
 
         # fill in subnet and security group, if they exist in env variable
         # and are not already set in the existing config (input JSON)

--- a/tibanna_ffcommon/vars.py
+++ b/tibanna_ffcommon/vars.py
@@ -19,14 +19,12 @@ if not GLOBAL_ENV_BUCKET:
     raise Exception('GLOBAL_ENV_BUCKET not present - redeploy Tibanna with it set!')
 AWSF_IMAGE = '%s.dkr.ecr.%s.amazonaws.com/tibanna-awsf:%s' % (AWS_ACCOUNT_NUMBER, AWS_REGION, tibanna_version)
 
-
 # cached bucket names (internally used by function BUCKET_NAME
 _BUCKET_NAME_PROCESSED_FILES = dict()
 _BUCKET_NAME_RAW_FILES = dict()
 _BUCKET_NAME_SYS = dict()
 _BUCKET_NAME_LOG = dict()
 _BUCKET_NAME_CWL = dict()
-
 
 # Workflow argument file types
 OUTPUT_PROCESSED_FILE = 'Output processed file'
@@ -35,6 +33,16 @@ OUTPUT_QC_FILE = 'Output QC file'
 GENERIC_QC_FILE = 'Generic QC file'
 OUTPUT_TO_BE_EXTRA_INPUT_FILE = 'Output to-be-extra-input file'
 INPUT_FILE = 'Input file'
+
+# Core file types
+OUTPUT_FILE  = 'OutputFile' # SMaHT
+SUBMITTED_FILE = 'SubmittedFile' # SMaHT
+REFERENCE_FILE = 'ReferenceFile' # SMaHT
+FILE_PROCESSED = 'FileProcessed' # CGAP/4DN
+FILE_FASTQ = 'FileFastq' # CGAP/4DN
+FILE_REFERENCE = 'FileReference' # CGAP/4DN
+FILE_SUBMITTED = 'FileSubmitted' # CGAP/4DN
+FILE_MICROSCOPY = 'FileMicroscopy' # 4DN
 
 
 # Secure Tibanna AMI
@@ -60,12 +68,12 @@ if AWS_REGION not in AMI_PER_REGION['x86']:
 def BUCKET_NAME(env, filetype):
     global _BUCKET_NAME_PROCESSED_FILES
     global _BUCKET_NAME_RAW_FILES
-    global _BUCKET_NAME_SYSG
+    global _BUCKET_NAME_SYS
     global _BUCKET_NAME_LOG
     global _BUCKET_NAME_CWL
 
-    processed_file_types = ['FileProcessed', 'OutputFile']
-    raw_file_types = ['FileFastq', 'FileReference', 'ReferenceFile', 'SubmittedFile', 'FileMicroscopy', 'FileSubmitted', 'UnalignedReads', 'AlignedReads', 'VariantCalls']
+    processed_file_types = [FILE_PROCESSED, OUTPUT_FILE]
+    raw_file_types = [FILE_FASTQ, FILE_REFERENCE, REFERENCE_FILE, SUBMITTED_FILE, FILE_MICROSCOPY, FILE_SUBMITTED]
 
     # use cache
     if filetype in processed_file_types and env in _BUCKET_NAME_PROCESSED_FILES:

--- a/tibanna_smaht/tiger_utils.py
+++ b/tibanna_smaht/tiger_utils.py
@@ -20,6 +20,10 @@ from .vars import (
     DEFAULT_CONSORTIUM,
     ACCESSION_PREFIX,
     HIGLASS_BUCKETS,
+    OUTPUT_FILE,
+    SUBMITTED_FILE,
+    REFERENCE_FILE,
+    BUCKET_NAME  
 )
 from tibanna_ffcommon.wfr import WorkflowRunMetadataAbstract, aslist
 from tibanna_ffcommon.portal_utils import (
@@ -36,6 +40,21 @@ logger = create_logger(__name__)
 
 
 class TigerInputFile(FFInputFile):
+
+    def get_bucket_name_from_uuid(self, uuid):
+        file_meta = self.get_metadata(uuid)
+        file_types = file_meta['@type']
+        file_type = file_types[0] # This is what is used in 4DN and CGAP
+        # We only want to use core file types when determining the correct bucket
+        if SUBMITTED_FILE in file_types:
+            file_type = SUBMITTED_FILE
+        elif REFERENCE_FILE in file_types:
+            file_type = REFERENCE_FILE
+        elif OUTPUT_FILE in file_types:
+            file_type = OUTPUT_FILE
+
+        return BUCKET_NAME(self.ff_env, file_type)
+        
     def get_file_format_from_uuid(self, uuid):
         """returns parsed (cleaned) version of file format (e.g. 'bam')"""
         file_format_uuid = parse_formatstr(self.get_metadata(uuid)["file_format"])

--- a/tibanna_smaht/vars.py
+++ b/tibanna_smaht/vars.py
@@ -1,33 +1,27 @@
 from tibanna_ffcommon.vars import *
 
-
 LAMBDA_TYPE = 'tiger'
 SFN_TYPE = 'tiger'
 ACCESSION_PREFIX = 'SMA'
 
-
 # default step function name
 TIBANNA_DEFAULT_STEP_FUNCTION_NAME = 'tibanna_' + LAMBDA_TYPE  # note that this is mismatched
-
 
 # smaht-specific attribution
 DEFAULT_CONSORTIUM = '358aed10-9b9d-4e26-ab84-4bd162da182b'
 DEFAULT_SUBMISSION_CENTER = '9626d82e-8110-4213-ac75-0a50adf890ff'
 
-
 HIGLASS_BUCKETS = []
-
 
 DEV_ENV = 'smaht-wolf'
 PROD_ENV = 'smaht-production'
-
 
 def IAM_BUCKETS(env):
     """ This function determines the buckets for which the IAM policy is generated for.
         If you want tibanna to have access to more buckets, this is where to add them.
     """
-    iam_buckets = [BUCKET_NAME(env, 'FileProcessed'),
-                   BUCKET_NAME(env, 'FileFastq'),  # this is a holdover, in SMaHT these are all FileSubmitted
+    iam_buckets = [BUCKET_NAME(env, OUTPUT_FILE),
+                   BUCKET_NAME(env, SUBMITTED_FILE),
                    BUCKET_NAME(env, 'system'),
                    BUCKET_NAME(env, 'log'),
                    BUCKET_NAME(env, 'cwl')]


### PR DESCRIPTION
Only use the file types  `OutputFile`, `SubmittedFile` and `ReferenceFile` to determine the correct bucket of a file in SMaHT. This way we don't have to maintain a list of all file types (e.g., `UnalignedReads`) in the code.

Nothing should change for 4DN and CGAP.