### PR TITLE
Support md5 workflows in SMaHT

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tibanna_ff"
-version = "3.3.0"
+version = "3.3.1"
 description = "Tibanna runs portable pipelines (in CWL/WDL) on the AWS Cloud."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/tibanna_smaht/tiger_utils.py
+++ b/tibanna_smaht/tiger_utils.py
@@ -351,18 +351,26 @@ class FourfrontUpdater(FourfrontUpdaterAbstract):
             uuid = of["value"]
             of_metadata = self.get_metadata(uuid)
 
-            output_files.append(
-                {
-                    "workflow_argument_name": of["workflow_argument_name"],
-                    "type": of["type"],
-                    "upload_key": of_metadata["upload_key"],
-                    "format": of_metadata["file_format"],
-                    "extra_files": of_metadata["extra_files"]
-                    if "extra_files" in of_metadata
-                    else [],
-                    "value": uuid,
-                }
-            )
+            if of_metadata['type'] == OUTPUT_REPORT_FILE:
+                output_files.append(
+                    {
+                        "workflow_argument_name": of["workflow_argument_name"],
+                        "type": of["type"],
+                    }
+                )
+            else:
+                output_files.append(
+                    {
+                        "workflow_argument_name": of["workflow_argument_name"],
+                        "type": of["type"],
+                        "upload_key": of_metadata["upload_key"],
+                        "format": of_metadata["file_format"],
+                        "extra_files": of_metadata["extra_files"]
+                        if "extra_files" in of_metadata
+                        else [],
+                        "value": uuid,
+                    }
+                )
 
         return output_files
 

--- a/tibanna_smaht/tiger_utils.py
+++ b/tibanna_smaht/tiger_utils.py
@@ -208,6 +208,7 @@ class WorkflowRunMetadata(WorkflowRunMetadataAbstract):
         output_files = copy.deepcopy(patch_dict["output_files"])
         restricted_output_files = []
         for of in output_files:
+            logger.debug("Ouput file " + json.dumps(of))
             restricted_output_files.append(
                 {
                     "workflow_argument_name": of["workflow_argument_name"],

--- a/tibanna_smaht/tiger_utils.py
+++ b/tibanna_smaht/tiger_utils.py
@@ -347,11 +347,8 @@ class FourfrontUpdater(FourfrontUpdaterAbstract):
     def set_ff_output_files(self):
         output_files = []
         for of in self.ff_meta.output_files:
-            # We need additional infos from the portal
-            uuid = of["value"]
-            of_metadata = self.get_metadata(uuid)
-
-            if of_metadata['type'] == OUTPUT_REPORT_FILE:
+            
+            if of['type'] == OUTPUT_REPORT_FILE:
                 output_files.append(
                     {
                         "workflow_argument_name": of["workflow_argument_name"],
@@ -359,6 +356,9 @@ class FourfrontUpdater(FourfrontUpdaterAbstract):
                     }
                 )
             else:
+                # We need additional infos from the portal
+                uuid = of["value"]
+                of_metadata = self.get_metadata(uuid)
                 output_files.append(
                     {
                         "workflow_argument_name": of["workflow_argument_name"],

--- a/tibanna_smaht/tiger_utils.py
+++ b/tibanna_smaht/tiger_utils.py
@@ -28,7 +28,8 @@ from tibanna_ffcommon.portal_utils import (
     FourfrontUpdaterAbstract,
     QualityMetricsGenericMetadataAbstract,
     FFInputAbstract,
-    QualityMetricGenericModel
+    QualityMetricGenericModel,
+    OUTPUT_REPORT_FILE
 )
 from tibanna import create_logger
 
@@ -208,7 +209,8 @@ class WorkflowRunMetadata(WorkflowRunMetadataAbstract):
         output_files = copy.deepcopy(patch_dict["output_files"])
         restricted_output_files = []
         for of in output_files:
-            logger.debug("Ouput file " + json.dumps(of))
+            if of['type'] == OUTPUT_REPORT_FILE:
+                continue
             restricted_output_files.append(
                 {
                     "workflow_argument_name": of["workflow_argument_name"],

--- a/tibanna_smaht/tiger_utils.py
+++ b/tibanna_smaht/tiger_utils.py
@@ -323,6 +323,9 @@ class FourfrontUpdater(FourfrontUpdaterAbstract):
 
     @property
     def app_name(self):
+        logger.info(f"md5 title: {self.ff_meta.title}")
+        if self.ff_meta.title and self.ff_meta.title.startswith("md5"):
+            return "md5"
         return self.ff_meta.title
 
     def update_metadata(self):

--- a/tibanna_smaht/tiger_utils.py
+++ b/tibanna_smaht/tiger_utils.py
@@ -217,7 +217,10 @@ class WorkflowRunMetadata(WorkflowRunMetadataAbstract):
                     "value": of["value"],
                 }
             )
-        patch_dict["output_files"] = restricted_output_files
+        if len(restricted_output_files) == 0:
+            del patch_dict["output_files"]
+        else:
+            patch_dict["output_files"] = restricted_output_files
         return patch_dict
 
 


### PR DESCRIPTION
These changes add support for the md5 workflow in SMaHT. It relies on `Output report file` and `app_name` which requires special handling in the SMahT layer. `app_name` is not something we have in the schema anymore (we generally don't need it), therefore the I am extracting it here from the workflow title. That's not ideal, but it was the easiest solution.