### PR TITLE
Remove explicit schema properties from QC values

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tibanna_ff"
-version = "3.4.1"
+version = "3.4.2"
 description = "Tibanna runs portable pipelines (in CWL/WDL) on the AWS Cloud."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/tibanna_4dn/lambdas/requirements.txt
+++ b/tibanna_4dn/lambdas/requirements.txt
@@ -4,4 +4,4 @@ botocore>=1.12.1
 dcicutils>7.0.0,<9
 tibanna>=5.0.0,<6
 requests==2.27.1
-pydantic>=2.4.2,<3
+pydantic>=2.4.2,<3.0.0

--- a/tibanna_cgap/lambdas/requirements.txt
+++ b/tibanna_cgap/lambdas/requirements.txt
@@ -4,4 +4,4 @@ botocore>=1.12.1
 dcicutils>7.0.0,<9
 tibanna>=5.0.0,<6
 requests==2.27.1
-pydantic>=2.4.2,<2.8.0
+pydantic>=2.4.2,<3.0.0

--- a/tibanna_cgap/lambdas/requirements.txt
+++ b/tibanna_cgap/lambdas/requirements.txt
@@ -4,4 +4,4 @@ botocore>=1.12.1
 dcicutils>7.0.0,<9
 tibanna>=5.0.0,<6
 requests==2.27.1
-pydantic>=2.4.2,<3
+pydantic>=2.4.2,<2.8.0

--- a/tibanna_smaht/lambdas/requirements.txt
+++ b/tibanna_smaht/lambdas/requirements.txt
@@ -4,4 +4,4 @@ botocore>=1.12.1
 dcicutils>7.0.0,<9
 tibanna>=5.0.0,<6
 requests==2.27.1
-pydantic>=2.4.2,<2.8.0
+pydantic>=2.4.2,<3.0.0

--- a/tibanna_smaht/lambdas/requirements.txt
+++ b/tibanna_smaht/lambdas/requirements.txt
@@ -4,4 +4,4 @@ botocore>=1.12.1
 dcicutils>7.0.0,<9
 tibanna>=5.0.0,<6
 requests==2.27.1
-pydantic>=2.4.2,<3
+pydantic>=2.4.2,<2.8.0

--- a/tibanna_smaht/tiger_utils.py
+++ b/tibanna_smaht/tiger_utils.py
@@ -273,17 +273,18 @@ class QualityMetricsGenericMetadata(QualityMetricsGenericMetadataAbstract):
         #self.name = qmg.name
         qc_values = []
         for qcv in qmg.qc_values:
-            qc_value = {
-                "key": qcv.key,
-                "value": qcv.value
-            }
-            available_keys = list(qcv.model_dump().keys()) # There does not seem to be a better way to get all keys (including extra fields) from a Pydantic model
+            qc_value = {}
+            # There does not seem to be a better way to get all keys (including extra fields) from a Pydantic model
+            # We are patching everything to the portal that we obtain from qc-parser and that is added by tibanna_ff
+            # in previous steps.
+            available_keys = list(qcv.model_dump().keys()) 
+            for key in available_keys:
+                qc_value[key] = qcv[key]
+
+            # flag come from the Tibanna internal model and needs to be converted to the SMaHT data model.
+            # This is, e.g., "Pass" as in the SMaHT data model
             if "flag" in available_keys:
-                qc_value["flag"] = qcv.flag.capitalize() # This is, e.g., "Pass" as in the SMaHT data model
-            if "tooltip" in available_keys:
-                qc_value["tooltip"] = qcv.tooltip
-            if "derived_from" in available_keys:
-                qc_value["derived_from"] = qcv.derived_from
+                qc_value["flag"] = qcv.flag.capitalize() 
 
             qc_values.append(qc_value)
 

--- a/tibanna_smaht/tiger_utils.py
+++ b/tibanna_smaht/tiger_utils.py
@@ -279,7 +279,7 @@ class QualityMetricsGenericMetadata(QualityMetricsGenericMetadataAbstract):
             # in previous steps.
             available_keys = list(qcv.model_dump().keys()) 
             for key in available_keys:
-                qc_value[key] = qcv[key]
+                qc_value[key] = getattr(qcv, key)
 
             # flag come from the Tibanna internal model and needs to be converted to the SMaHT data model.
             # This is, e.g., "Pass" as in the SMaHT data model


### PR DESCRIPTION
Generalize how `qc_values` within a `QualityMetric` items are patched to the portal. Instead of listing every property we want to patch to the portal in Tibanna, we patch everything we get from qc_parser to the portal. This way we only need to change qc_parser when adding new properties (and the portal schema of course).