### PR TITLE
migrate all workflows to OIDC auth

### DIFF
--- a/.github/workflows/main-deploy-pony-data.yml
+++ b/.github/workflows/main-deploy-pony-data.yml
@@ -7,6 +7,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions: #Needed for OIDC authentication
+  id-token: write
+  contents: read    
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -30,10 +33,9 @@ jobs:
           make install
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Deploy pony data

--- a/.github/workflows/main-deploy-pony-webdev.yml
+++ b/.github/workflows/main-deploy-pony-webdev.yml
@@ -6,7 +6,9 @@ name: deploy-pony-webdev
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-
+permissions: #Needed for OIDC authentication
+  id-token: write
+  contents: read
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -30,10 +32,9 @@ jobs:
           make install
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Deploy pony webdev

--- a/.github/workflows/main-run-tests.yml
+++ b/.github/workflows/main-run-tests.yml
@@ -7,6 +7,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions: #Needed for OIDC authentication
+  id-token: write
+  contents: read    
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -30,10 +33,9 @@ jobs:
           make install
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Run tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions: #Needed for OIDC authentication
+  id-token: write
+  contents: read    
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -29,10 +32,9 @@ jobs:
           python-version: 3.11
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Install Poetry


### PR DESCRIPTION
## Summary
Replaces static AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY GitHub secrets 
with OIDC role assumption across all workflows. This is more secure 
as it eliminates long-lived AWS credentials stored as GitHub secrets.

## Changes

- `main-run-tests.yml` — switched to OIDC auth
- `main.ym` — switched to OIDC auth  
- `main-deploy-pony-data.yml` — switched to OIDC auth
- 'main-deploy-pony-webdev.yml' — switched to OIDC auth
- All three: bumped `configure-aws-credentials` v1 → v4 (required for OIDC)
- All three: added `permissions: id-token: write` block (required for GitHub to issue OIDC token)

## Testing
- ✅ CI passed on this branch (see Notes for pre-existing failures unrelated to this change)
- ✅ AWS credentials step passes with OIDC role assumption confirmed

## After this is merged
The following repo secrets can be deleted by an admin if not used in other areas of the pipeline:
- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`

`AWS_OIDC_ROLE_ARN` must remain.

## Notes

**Pre-existing CI failures not related to this change:**

**`test_input_extra` — Higlass registration returned no UUID**
The test POSTs to the Higlass API to register a tile but receives an error 
response instead of a UUID:

  {"error": "Specified file (...4DNFINGT4SXC.bed.multires.mv5) does not exist"}

`res.json()['uuid']` then throws a KeyError because there is no `uuid` key 
in the error response. The fix should be in `portal_utils.py:1782` the code 
needs to handle Higlass error responses gracefully by checking for `uuid` in 
the response before accessing it, similar to how the `except` block above it 
already swallows connection errors. Pre-existing issue, out of scope for this PR.