### PR TITLE
Add possibility to override the EC2 AMI at deploy time

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Change Log
 3.11.0
 =====
 * Add optional ``AMI_ID`` env var to override the EC2 AMI at deploy time (an explicit ``ami_id`` in the input JSON still takes precedence)
-* Update default AMI and pin tibanna to 6.0.1b4
+* Update default AMI and pin tibanna to 6.1.0
 
 
 3.10.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Change Log
 ==========
 
+3.11.0
+=====
+* Add optional ``AMI_ID`` env var to override the EC2 AMI at deploy time (an explicit ``ami_id`` in the input JSON still takes precedence)
+* Update default AMI and pin tibanna to 6.0.1b4
+
+
 3.10.0
 =====
 * Support open data buckets in SMaHT

--- a/poetry.lock
+++ b/poetry.lock
@@ -2550,14 +2550,14 @@ files = [
 
 [[package]]
 name = "tibanna"
-version = "6.0.0"
+version = "6.0.1b4"
 description = "Tibanna runs portable pipelines (in CWL/WDL) on the AWS Cloud."
 category = "main"
 optional = false
 python-versions = "<3.13,>=3.8"
 files = [
-    {file = "tibanna-6.0.0-py3-none-any.whl", hash = "sha256:bc2a745bd83153ff759a2451a3651bee17e33c6957b2f1624824064a763670e7"},
-    {file = "tibanna-6.0.0.tar.gz", hash = "sha256:18693130818bae54c337310c5ecb7be4b3abc6339fdeb0f63c656ff230abe949"},
+    {file = "tibanna-6.0.1b4-py3-none-any.whl", hash = "sha256:1cff7f038206ec384a25bb02ccb6d26ffb207f123c76acbc12c10324a65ff017"},
+    {file = "tibanna-6.0.1b4.tar.gz", hash = "sha256:7f4c08299b8ea1b5fca5ffe600701d13b84a04d7aa3aa344fb5b003bc0b82118"},
 ]
 
 [package.dependencies]
@@ -2900,4 +2900,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.13"
-content-hash = "c99bc68bbaa892e0056e9701d1ce83a3fe83c9fe06b23a915111d91866c71a3a"
+content-hash = "3f29b69b28a280046f0fb87b9fb96d89f4baee4a9a5865c67bb9bf8adc9c078f"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2550,14 +2550,14 @@ files = [
 
 [[package]]
 name = "tibanna"
-version = "6.0.1b4"
+version = "6.1.0"
 description = "Tibanna runs portable pipelines (in CWL/WDL) on the AWS Cloud."
 category = "main"
 optional = false
 python-versions = "<3.13,>=3.8"
 files = [
-    {file = "tibanna-6.0.1b4-py3-none-any.whl", hash = "sha256:1cff7f038206ec384a25bb02ccb6d26ffb207f123c76acbc12c10324a65ff017"},
-    {file = "tibanna-6.0.1b4.tar.gz", hash = "sha256:7f4c08299b8ea1b5fca5ffe600701d13b84a04d7aa3aa344fb5b003bc0b82118"},
+    {file = "tibanna-6.1.0-py3-none-any.whl", hash = "sha256:eeb2b75d1abec9023dfce0b1e2e9f300f1104c1e0f1cabf237c51c9d178f7c80"},
+    {file = "tibanna-6.1.0.tar.gz", hash = "sha256:a14a92e31d8e345df869d1e5fe03b6983e6c220e4daf1288285ece8d08c09dde"},
 ]
 
 [package.dependencies]
@@ -2900,4 +2900,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.13"
-content-hash = "3f29b69b28a280046f0fb87b9fb96d89f4baee4a9a5865c67bb9bf8adc9c078f"
+content-hash = "49e14f87a61cbbbcead5780bc4875c3ebf844f026ecf8d645c0f7316ae8f9b5a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.13"
-tibanna = "^6.0.0"
+tibanna = "6.0.1b4"
 dcicutils = "^8.13.3"
 boto3 = "^1.34.147"
 botocore = "^1.34.147"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<3.13"
-tibanna = "6.0.1b4"
+tibanna = "^6.1.0"
 dcicutils = "^8.13.3"
 boto3 = "^1.34.147"
 botocore = "^1.34.147"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tibanna_ff"
-version = "3.10.0"
+version = "3.11.0"
 description = "Tibanna runs portable pipelines (in CWL/WDL) on the AWS Cloud."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/tibanna_ffcommon/core.py
+++ b/tibanna_ffcommon/core.py
@@ -13,7 +13,8 @@ from .vars import (
     BUCKET_NAME,
     GLOBAL_ENV_BUCKET,
     AWSF_IMAGE,
-    AMI_PER_REGION
+    AMI_PER_REGION,
+    AMI_ID
 )
 
 
@@ -63,6 +64,9 @@ class API(_API):
             envlist_ff['update_ffmeta'].update({'GLOBAL_ENV_BUCKET': GLOBAL_ENV_BUCKET})
         if AWSF_IMAGE:
             envlist_ff['start_run'].update({'AWSF_IMAGE': AWSF_IMAGE})
+        if AMI_ID:
+            # start_run (FFInputAbstract) reads this to override the AMI at submission time
+            envlist_ff['start_run'].update({'AMI_ID': AMI_ID})
         for _, envs in envlist_ff.items():
             envs.update({'TIBANNA_FF_VERSION': __version__})
         return envlist_ff.get(name, '')

--- a/tibanna_ffcommon/portal_utils.py
+++ b/tibanna_ffcommon/portal_utils.py
@@ -45,7 +45,8 @@ from .vars import (
     OUTPUT_TO_BE_EXTRA_INPUT_FILE,
     INPUT_FILE,
     AWSF_IMAGE,
-    FILE_PROCESSED
+    FILE_PROCESSED,
+    AMI_ID
 )
 from .config import (
     higlass_config
@@ -190,6 +191,13 @@ class FFInputAbstract(SerializableObject):
             self.config.subnet = possible_subnets  # pass all subnets to config
         if not self.config.security_group and os.environ.get('SECURITY_GROUPS', ''):
             self.config.security_group = os.environ['SECURITY_GROUPS'].split(',')[0]
+        # fill in the AMI from the deploy-time AMI_ID env var, same "config takes priority" rule
+        # as subnet/security_group above. Foursight stamps ami_per_region (not ami_id), and
+        # ec2_utils prefers a set ami_id over ami_per_region, so this env default still wins over
+        # whatever Foursight submits - letting a tibanna_ff redeploy switch the AMI - while an
+        # explicit ami_id in the input JSON still takes precedence.
+        if not self.config.ami_id and AMI_ID:
+            self.config.ami_id = AMI_ID
 
     def as_dict(self):
         d_shallow = self.__dict__.copy()

--- a/tibanna_ffcommon/vars.py
+++ b/tibanna_ffcommon/vars.py
@@ -67,6 +67,14 @@ if AWS_REGION not in AMI_PER_REGION['x86']:
     raise Exception('')
 
 
+# Optional deploy-time AMI override (single id), baked into the Lambdas via env_list. Fills in
+# config.ami_id (an explicit ami_id in the input JSON still wins), which ec2_utils prefers over
+# ami_per_region for every instance - so it overrides the ami_per_region the caller (e.g.
+# Foursight) stamps at submission, letting a redeploy switch the AMI without bumping the
+# caller's tibanna_ff. Single x86 AMI in us-east-1 here; for multi-arch/region use ami_per_region.
+AMI_ID = os.environ.get('AMI_ID', None)
+
+
 def BUCKET_NAME(env, filetype):
     global _BUCKET_NAME_PROCESSED_FILES
     global _BUCKET_NAME_RAW_FILES

--- a/tibanna_ffcommon/vars.py
+++ b/tibanna_ffcommon/vars.py
@@ -53,7 +53,7 @@ FILE_MICROSCOPY = 'FileMicroscopy' # 4DN
 # accounts
 AMI_PER_REGION = {
     'x86': {
-        'us-east-1': 'ami-0afc2a6bf9a8c35c6',
+        'us-east-1': 'ami-06d4faf5c6fb2a886',
         'us-east-2': 'ami-019d106d5006c260b'
     },
     'Arm': {

--- a/tibanna_ffcommon/vars.py
+++ b/tibanna_ffcommon/vars.py
@@ -67,7 +67,7 @@ FILE_MICROSCOPY = 'FileMicroscopy' # 4DN
 # via the AMI_ID env var, which overrides the AMI_PER_REGION setting below.
 AMI_PER_REGION = {
     'x86': {
-        'us-east-1': 'ami-06d4faf5c6fb2a886', # Ubuntu 26.04 secure AMI
+        'us-east-1': 'ami-0a2ab24be8532f3bd', # Ubuntu 26.04 secure AMI
     }
 }
 

--- a/tibanna_ffcommon/vars.py
+++ b/tibanna_ffcommon/vars.py
@@ -51,14 +51,23 @@ FILE_MICROSCOPY = 'FileMicroscopy' # 4DN
 # Note that this means only these regions will work (replicate AMI in main account as needed)
 # Note additionally that these AMI's all must be configured to be launchable by our AWS
 # accounts
+# AMI_PER_REGION = {
+#     'x86': {
+#         'us-east-1': 'ami-06d4faf5c6fb2a886', # Ubuntu 26.04 secure AMI
+#         'us-east-2': 'ami-019d106d5006c260b' # Ubuntu 20.04 secure AMI
+#     },
+#     'Arm': {
+#         'us-east-1': 'ami-0f62f740c44080b8f', # Ubuntu 20.04 secure AMI
+#         'us-east-2': 'ami-01bec7663ee3ab696' # Ubuntu 20.04 secure AMI
+#     }
+# }
+
+# Our bioinformatics pipelines currently only support x86,
+# and we are only running in us-east-1.  Specific AMIs can be used
+# via the AMI_ID env var, which overrides the AMI_PER_REGION setting below.
 AMI_PER_REGION = {
     'x86': {
-        'us-east-1': 'ami-06d4faf5c6fb2a886',
-        'us-east-2': 'ami-019d106d5006c260b'
-    },
-    'Arm': {
-        'us-east-1': 'ami-0f62f740c44080b8f',
-        'us-east-2': 'ami-01bec7663ee3ab696'
+        'us-east-1': 'ami-06d4faf5c6fb2a886', # Ubuntu 26.04 secure AMI
     }
 }
 

--- a/tibanna_smaht/lambdas/requirements.txt
+++ b/tibanna_smaht/lambdas/requirements.txt
@@ -2,6 +2,6 @@ Benchmark-4dn>=0.5.13
 boto3>=1.9.0
 botocore>=1.12.1
 dcicutils>7.0.0,<9
-tibanna==6.0.1b4
+tibanna>=6.0.0,<7
 requests==2.27.1
 pydantic>=2.4.2,<3.0.0

--- a/tibanna_smaht/lambdas/requirements.txt
+++ b/tibanna_smaht/lambdas/requirements.txt
@@ -2,6 +2,6 @@ Benchmark-4dn>=0.5.13
 boto3>=1.9.0
 botocore>=1.12.1
 dcicutils>7.0.0,<9
-tibanna>=6.0.0,<7
+tibanna==6.0.1b4
 requests==2.27.1
 pydantic>=2.4.2,<3.0.0


### PR DESCRIPTION
* Add optional ``AMI_ID`` env var to override the EC2 AMI at deploy time (an explicit ``ami_id`` in the input JSON still takes precedence)
* Update default AMI and pin tibanna to 6.1.0